### PR TITLE
rename infiltration rate -> base infiltration and remove doubled conditions

### DIFF
--- a/arch/custom_usages/UseConditionsAC20-FZK-Haus.json
+++ b/arch/custom_usages/UseConditionsAC20-FZK-Haus.json
@@ -18,7 +18,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.5,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -187,7 +187,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.5,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -356,7 +356,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -525,7 +525,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -694,7 +694,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -863,7 +863,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,

--- a/arch/custom_usages/UseConditionsExampleHOM.json
+++ b/arch/custom_usages/UseConditionsExampleHOM.json
@@ -3,7 +3,6 @@
     "Traffic area": {
         "with_heating": true,
         "T_threshold_heating": 288.15,
-        "T_threshold_cooling": 295.15,
         "with_cooling": true,
         "T_threshold_cooling": 295.15,
         "persons": 0.0,
@@ -19,7 +18,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -175,7 +174,6 @@
         "T_threshold_heating": 288.15,
         "T_threshold_cooling": 295.15,
         "with_cooling": true,
-        "T_threshold_cooling": 295.15,
         "persons": 0.0,
         "activity_degree_persons": 1.2,
         "fixed_heat_flow_rate_persons": 70,
@@ -189,7 +187,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -358,7 +356,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.5,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -527,7 +525,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.5,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,

--- a/arch/custom_usages/UseConditionsFM_ARC_DigitalHub.json
+++ b/arch/custom_usages/UseConditionsFM_ARC_DigitalHub.json
@@ -13,12 +13,11 @@
         "machines": 7.0,
         "ratio_conv_rad_machines": 0.75,
         "fixed_lighting_power": 12.5,
-        "ratio_conv_rad_lighting": 0.9,
         "maintained_illuminance": 500.0,
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -187,7 +186,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -356,7 +355,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -525,7 +524,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -681,7 +680,6 @@
         "T_threshold_heating": 288.15,
         "T_threshold_cooling": 295.15,
         "with_cooling": true,
-        "T_threshold_cooling": 295.15,
         "persons": 0.0,
         "activity_degree_persons": 1.2,
         "fixed_heat_flow_rate_persons": 70,
@@ -695,7 +693,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -864,7 +862,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -1033,7 +1031,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -1202,7 +1200,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -1358,7 +1356,6 @@
         "T_threshold_heating": 288.15,
         "T_threshold_cooling": 295.15,
         "with_cooling": true,
-        "T_threshold_cooling": 295.15,
         "persons": 0.0,
         "activity_degree_persons": 1.2,
         "fixed_heat_flow_rate_persons": 70,
@@ -1372,7 +1369,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -1541,7 +1538,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": true,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,


### PR DESCRIPTION
adjusts the useconditions files to the new teaser version 1.1.0

pipeline runs here: https://git.rwth-aachen.de/EBC/EBC_all/github_ci/bim2sim/-/pipelines/1560508

Looking good:
![image](https://github.com/user-attachments/assets/9bd5cb1a-dfe3-4643-91d3-3afece1a6860)